### PR TITLE
Add test for hashchange event

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple and portable router for the client and server.",
   "main": "index.js",
   "scripts": {
-    "test": "standard && node test.js && zuul --local 9966 -- test.js",
+    "test": "standard && tape test/*.js && zuul --local 9966 -- test/*.js",
     "ci": "standard && node test.js && zuul -- test.js",
     "start": "budo example.js --live"
   },

--- a/test/events.js
+++ b/test/events.js
@@ -1,0 +1,30 @@
+var Router = require('../')
+var test = require('tape')
+var location = require('global/window').location
+
+if (location) {
+  test('hashchange', function (t) {
+    t.plan(6)
+    var first = true
+    var router = new Router({
+      '/one': function () { return 1 },
+      '/two': function () { return 2 }
+    }, {location: 'hash'})
+    router.on('transition', function (route, data) {
+      if (first) {
+        first = false
+        t.equal(route, '/one')
+        t.equal(location.hash, '#/one')
+        t.equal(data, 1)
+        router.transitionTo('/two')
+      } else {
+        t.equal(route, '/two')
+        t.equal(location.hash, '#/two')
+        t.equal(data, 2)
+        t.end()
+      }
+    })
+    location.hash = '#/one'
+  })
+}
+module.exports = {}

--- a/test/router.js
+++ b/test/router.js
@@ -1,5 +1,5 @@
 var test = require('tape')
-var Router = require('./index.js')
+var Router = require('../')
 
 test('return data', function (t) {
   t.plan(6)


### PR DESCRIPTION
##### Notes
- Moved tests into separate directory and spun event tests off into their own file. Nothing more than an organizational change so this can be changed back if necessary
- Used `setTimeout` to wait for `Router.currentRoute` to change. Could do this more elegantly but might call for a new `Router` promise to grab `currentRoute` and a minor semver bump? Curious about other solutions here
- Didn't test server-side behavior since code uses `window.addEventListener` 

Just let me know what you want changed/improved/fixed/done differently here! 
If this goes through I'll follow up with the tests for `window.history` ;)
