### PR TITLE
deps: wayfarer -> routington

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = Router
 
 var EE = require('events').EventEmitter
 var inherits = require('inherits')
-var createRouter = require('wayfarer')
+var createRouter = require('routington')
 
 function Router (routes, opts) {
   if (!(this instanceof Router)) return new Router(routes, opts)
@@ -21,7 +21,8 @@ function Router (routes, opts) {
 inherits(Router, EE)
 
 Router.prototype.route = function BaseRouter_route (name, model) {
-  this._router.on(name, model)
+  var node = this._router.define(name)[0]
+  node.cb = model
 }
 
 Router.prototype.transitionTo = function BaseRouter_transitionTo (name, params, cb) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   "dependencies": {
     "global": "^4.3.0",
     "inherits": "^2.0.1",
-    "wayfarer": "^3.1.0"
+    "routington": "^1.0.3"
   }
 }


### PR DESCRIPTION
I created this PR to test the assumptions made in https://github.com/yoshuawuyts/wayfarer/issues/17 (e.g. `routington` being a suitable replacement for `wayfarer` for this use case). Using `routington` should also be more efficient since only a single trie lookup happens (and there are less levels of indirection). Thanks!
## Changes
- **deps**: moved from `wayfarer` to `routington`
