### PR TITLE
Switch to use pathname-match

### DIFF
--- a/example.js
+++ b/example.js
@@ -50,14 +50,16 @@ App.prototype.render = function (page, data) {
   ]))
 }
 
+var app
+
 if (process.browser) {
   // On the client side
-  var app = new App(document.body)
+  app = new App(document.body)
   app.router.transitionTo('/posts/one')
 } else {
   // On the server side
   var toHTML = require('vdom-to-html')
-  var app = new App(false)
+  app = new App(false)
   var middleware = app.router.serve(function (page, data) {
     app.render(page, data)
     this.response.writeHead(200, { 'Content-Type': 'text/html' })

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ Router.prototype.serve = function BaseRouter_serve (fn) {
       request: request,
       response: response
     }
-    var name = require('url').parse(request.url).pathname
+    var name = require('pathname-match')(request.url)
     self.once('transition', function (route, data) {
       fn.call(ctx, route, data)
     })

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "global": "^4.3.0",
     "inherits": "^2.0.1",
+    "pathname-match": "^1.1.3",
     "routington": "^1.0.3"
   }
 }


### PR DESCRIPTION
This shaves a few bytes of the bundle size when using browserify by using [`pathname-match`](https://github.com/yoshuawuyts/pathname-match) and avoiding `require('url')`.

Pending #1 
